### PR TITLE
midipix like linux has /proc and dlopen(3)

### DIFF
--- a/src/common/extlib.c
+++ b/src/common/extlib.c
@@ -22,7 +22,7 @@
  #define WIN_EXTLIB
  #define LIB_EXT ".dll"
  #define DEFAULT_PATH "c:/sbasic/lib"
-#elif defined(__linux__) && defined(_UnixOS)
+#elif defined(__linux__) || defined(__midipix__) && defined(_UnixOS)
  #include <dlfcn.h>
  #define LNX_EXTLIB
  #define LIB_EXT ".so"

--- a/src/platform/sdl/main.cpp
+++ b/src/platform/sdl/main.cpp
@@ -249,7 +249,7 @@ void setupAppPath(const char *path) {
     strlcpy(g_appPath, cwd, sizeof(g_appPath));
     strlcat(g_appPath, "/", sizeof(g_appPath));
     strlcat(g_appPath, path, sizeof(g_appPath));
-#if defined(__linux__)
+#if defined(__linux__) || defined(__midipix__)
     if (access(g_appPath, X_OK) != 0) {
       // launched via PATH, retrieve full path
       ssize_t len = ::readlink("/proc/self/exe", g_appPath, sizeof(g_appPath));


### PR DESCRIPTION
Perhaps /proc/self/exe and dlopen(3) should instead be tested for at configure time?