### PR TITLE
Fix EQV bug. "0 EQV 0" will return correct result "1"

### DIFF
--- a/samples/distro-examples/tests/eval-test.bas
+++ b/samples/distro-examples/tests/eval-test.bas
@@ -193,6 +193,10 @@ assertEq 0xcccccccc Imp 0xaaaaaaaa, 0xbbbbbbbb, PROGLINE
 assertEq 0xcccc Imp 0xaaaa, 0xbbbb, PROGLINE
 assertEq 0xcc Imp 0xaa, 0xbb, PROGLINE
 assertEq 0xc Imp 0xa, 0xb, PROGLINE
+assertEq 0 Imp 0, 1, PROGLINE
+assertEq 0 Imp 1, 1, PROGLINE
+assertEq 1 Imp 0, 0, PROGLINE
+assertEq 1 Imp 1, 1, PROGLINE
 
 ' The Eqv operator returns 1 if and only if both inputs are equal.
 ' 1100
@@ -203,6 +207,10 @@ assertEq 0xcccccccc Eqv 0xaaaaaaaa, 0x99999999, PROGLINE
 assertEq 0xcccc Eqv 0xaaaa, 0x9999, PROGLINE
 assertEq 0xcc Eqv 0xaa, 0x99, PROGLINE
 assertEq 0xc Eqv 0xa, 0x9, PROGLINE
+assertEQ 0 EQV 0, 1, PROGLINE
+assertEQ 0 EQV 1, 0, PROGLINE
+assertEQ 1 EQV 0, 0, PROGLINE
+assertEQ 1 EQV 1, 1, PROGLINE
 
 ' bit shift operators
 assertEq 0xFF  LSHIFT 1, 0x1FE, PROGLINE

--- a/src/common/eval.c
+++ b/src/common/eval.c
@@ -531,6 +531,12 @@ static inline void oper_log(var_t *r, var_t *left) {
     b = ri;
     ri = 0;
     set = 0;
+
+    if ((a == 0) & (b == 0)) {
+      ri = 1;
+      break;
+    }
+
     for (i = (sizeof(var_int_t) * 8) - 1; i >= 0; i--) {
       int ba = ((a >> i) & 1);
       int bb = ((b >> i) & 1);

--- a/src/common/eval.c
+++ b/src/common/eval.c
@@ -553,6 +553,12 @@ static inline void oper_log(var_t *r, var_t *left) {
     b = ri;
     ri = 0;
     set = 0;
+
+    if ((a == 0) & (b == 0)) {
+      ri = 1;
+      break;
+    }
+    
     for (i = (sizeof(var_int_t) * 8) - 1; i >= 0; i--) {
       int ba = ((a >> i) & 1);
       int bb = ((b >> i) & 1);


### PR DESCRIPTION
Hi Chris,

EQV works fine but not for 0 EQV 0 which returns 0. Now 0 EQV 0 will return 1.

Best regards, Joerg