### PR TITLE
Fix bug in BGETC when using sockets

### DIFF
--- a/samples/distro-examples/tests/output/socket-io.out
+++ b/samples/distro-examples/tests/output/socket-io.out
@@ -1,0 +1,2 @@
+Client connection closed
+Server connection closed

--- a/samples/distro-examples/tests/socket-io-client.bas
+++ b/samples/distro-examples/tests/socket-io-client.bas
@@ -1,0 +1,27 @@
+#!../../../src/platform/console/sbasic
+
+' This file (socket_io_client.bas) will be called by socket_io.bas
+' Shebang needs to link to correct sbasic file.
+
+open "SOCL:127.0.0.1:10000" as #1
+
+' Test bputc and bgetc
+for byte = 0 to 255
+    bputc #1, byte
+next
+
+' Test print
+print #1, "Test1234"
+print #1, "Test-1234"
+print #1, "Test1234"
+
+' Test EOF bug
+byte = 0
+bputc #1, byte
+
+' Test LOF
+print #1, "Test1234"
+
+close #1
+
+print "Client connection closed"

--- a/samples/distro-examples/tests/socket-io.bas
+++ b/samples/distro-examples/tests/socket-io.bas
@@ -1,0 +1,36 @@
+' socket-io.bas will start a socket client. The client will send data.
+' socket-io.bas will check if data was received correctly
+
+' make socket-io-client.bas executable and then execute it
+chmod "../../../samples/distro-examples/tests/socket-io-client.bas", 0o777
+exec "../../../samples/distro-examples/tests/socket-io-client.bas"
+
+open "SOCL:10000" as #1
+
+' Test bputc and bgetc
+for ii = 0 to 255
+    Recv = bgetc(1)
+    if(Recv != ii) then throw "BGETC: " + ii + " expected, received " + Recv        
+next
+
+' Test print and input
+input #1, ans
+if(ans != "Test1234") then throw "INPUT: Test1234 expected, received " + ans
+
+input #1, ans, "-", ans2
+if(ans != "Test") then throw "INPUT: Test expected, received " + ans
+if(ans2 != "1234") then throw "INPUT: 1234 expected, received " + ans2
+
+ans = input(9, 1)
+if(ans != "Test1234\n") then throw "INPUT: Test1234 expected, received " + "\"" + ans + "\""    
+
+' Test for bug in SB 12.25: when "0" is received, EOF should not return true
+ans = bgetc(1)
+if(EOF(1)) then throw "EOF: zero received and eof returns true"
+
+' Test LOF
+if(LOF(1) != 9) then throw "LOF: 9 bytes expected. " + LOF(1) + " bytes waiting."
+
+close #1
+
+print "Server connection closed"

--- a/src/common/fs_socket_client.c
+++ b/src/common/fs_socket_client.c
@@ -245,7 +245,7 @@ int sockcl_eof(dev_file_t *f) {
 }
 
 //
-// returns the size of the data which are waiting in stream's queue
+// returns the size of data waiting in stream's queue
 //
 int sockcl_length(dev_file_t *f) {
   return net_peek((socket_t) (long) f->handle);

--- a/src/common/inet.h
+++ b/src/common/inet.h
@@ -134,7 +134,7 @@ void net_disconnect(socket_t s);
 /**
  * @ingroup net
  *
- * returns true if something is waiting in input-buffer
+ * returns number of bytes waiting in input-buffer
  *
  * @param s the socket
  * @return non-zero if something is waiting in input-buffer; otherwise returns 0

--- a/src/common/inet2.c
+++ b/src/common/inet2.c
@@ -161,9 +161,6 @@ int net_input(socket_t s, char *buf, int size, const char *delim) {
     if (bytes <= 0) {
       return count;             // no more data
     } else {
-      if (ch == 0) {
-        return count;
-      }
       if (delim) {
         if ((strchr(delim, ch) != NULL)) {
           return count;         // delimiter found
@@ -178,19 +175,19 @@ int net_input(socket_t s, char *buf, int size, const char *delim) {
 }
 
 /**
- * return true if there something waiting
+ * return available data in bytes
  */
 int net_peek(socket_t s) {
 #if defined(_Win32)
   unsigned long bytes;
 
   ioctlsocket(s, FIONREAD, &bytes);
-  return (bytes > 0);
+  return (bytes);
 #else
   int bytes;
 
   ioctl(s, FIONREAD, &bytes);
-  return (bytes > 0);
+  return (bytes);
 #endif
 }
 

--- a/src/platform/console/Makefile.am
+++ b/src/platform/console/Makefile.am
@@ -34,7 +34,8 @@ TEST_DIR=../../../samples/distro-examples/tests
 UNIT_TESTS=array break byref eval-test iifs matrices metaa ongoto \
 	         uds hash pass1 call_tau short-circuit strings stack-test \
            replace-test read-data proc optchk letbug ptr ref input \
-           trycatch chain stream-files split-join sprint all scope goto keymap
+           trycatch chain stream-files split-join sprint all scope \
+           goto keymap socket-io
 
 test: ${bin_PROGRAMS}
 	@for utest in $(UNIT_TESTS); do                             \


### PR DESCRIPTION
Hi Chris,

at the moment I'm using sockets a lot to communicate  from PC with a Raspberry Pi. Works very well and is programmed fast and easy.

I realized a bug with BGETC. When sending a zero with BPUTC, the zero was interpreted as end-of-connection and EOF returned true. I fixed this.

The second inconsistency I realized was, that LOF only returns that data is waiting, but not how much data. I changed this. Now it is possible to query how much data is in the queue and use INPUT(len, file) to get all the data in one go. I hope that there are not to much basic scripts, which will make trouble now.

To test the socket communication, I added a unit test. It will only work in Linux and is a little bit tricky. Please have a look, if this is OK for you.

Best regards, Joerg