### PR TITLE
Bugfixes for LINEQN and floating-point string conversion 

### DIFF
--- a/samples/distro-examples/tests/all.bas
+++ b/samples/distro-examples/tests/all.bas
@@ -245,3 +245,4 @@ print "VAL:" + VAL (s)
 print "WEEKDAY:" + WEEKDAY(dmy) + " " + WEEKDAY(1,1,2020) + " " + WEEKDAY(JULIAN(d,m,y))
 print "XPOS:" + XPOS
 print "YPOS:" + YPOS
+print "RoundPrecisionBug:"; 32.99999999999999

--- a/samples/distro-examples/tests/output/all.out
+++ b/samples/distro-examples/tests/output/all.out
@@ -228,3 +228,4 @@ VAL:0
 WEEKDAY:-1 3 1
 XPOS:0
 YPOS:0
+RoundPrecisionBug:33

--- a/src/common/blib_math.c
+++ b/src/common/blib_math.c
@@ -121,7 +121,7 @@ void mat_gauss_jordan(var_num_t *a, var_num_t *b, int n, double toler) {
     indxr[i] = irow;
     indxc[i] = icol;
 
-    if (a[icol * n + icol] < toler) {
+    if (fabs(a[icol * n + icol]) < toler) {
       err_matsig();
       free(indxc);
       free(indxr);

--- a/src/common/fmt.c
+++ b/src/common/fmt.c
@@ -183,7 +183,7 @@ void bestfta_p(var_num_t x, char *dest, var_num_t minx, var_num_t maxx) {
   }
   fpart = fround(frac(x), precision) * pow(10, precision);
 
-  if (fpart >= FMT_xRND) {      // rounding bug
+  if (fpart >= pow(10, precision)) {      // rounding bug, i.e: print 32.99999999999999 -> Output: 32.1
     ipart = ipart + 1.0;
     if (ipart >= maxx) {
       ipart = ipart / 10.0;


### PR DESCRIPTION
Hi Chris,

here are fixes for the two bugs reported by jsalai  (https://www.syntaxbomb.com/smallbasic/bug-s-in-lineqn/):

- Tolerance in LINEQN is now applied in the intended way.
- Floating-point to string conversion will round correctly when number has maximum possible precision.

Best regards, Joerg