### PR TITLE
Fix: RTRIM changes input string

### DIFF
--- a/samples/distro-examples/tests/strings.bas
+++ b/samples/distro-examples/tests/strings.bas
@@ -210,3 +210,8 @@ for t in number_test
   if (t[2] != oct(t[0])) then throw "err: oct(" + str(t[0]) + ") <> " + t[2]
   if (t[3] != hex(t[0])) then throw "err: hex(" + str(t[0]) + ") <> " + t[3]
 next
+
+REM Bug: RTRIM trimed input string on the right side
+s1 = "   test   "
+s2 = rtrim(s1)
+if(s1 != "   test   ") then throw "err: RTRIM changed input string"

--- a/src/common/blib_func.c
+++ b/src/common/blib_func.c
@@ -1053,8 +1053,8 @@ void cmd_str1(long funcCode, var_t *arg, var_t *r) {
     uint32_t len = strlen(arg->v.p.ptr);
     if (*p != '\0') {
       p = p + len - 1; 
-      while (is_wspace(*p)) {
-        len--;
+      while (p >= arg->v.p.ptr && is_wspace(*p)) {
+        len--;      
         p--;
       }
     }

--- a/src/common/blib_func.c
+++ b/src/common/blib_func.c
@@ -1050,19 +1050,17 @@ void cmd_str1(long funcCode, var_t *arg, var_t *r) {
       break;
     }
     p = arg->v.p.ptr;
+    uint32_t len = strlen(arg->v.p.ptr);
     if (*p != '\0') {
-      while (*p) {
-        p++;
-      }
-      p--;
-      while (p >= arg->v.p.ptr && (is_wspace(*p))) {
+      p = p + len - 1; 
+      while (is_wspace(*p)) {
+        len--;
         p--;
       }
-      p++;
-      *p = '\0';
     }
-    r->v.p.ptr = (char *)malloc(strlen(arg->v.p.ptr) + 1);
-    strcpy(r->v.p.ptr, arg->v.p.ptr);
+    r->v.p.ptr = (char *)malloc(len + 1);
+    strncpy(r->v.p.ptr, arg->v.p.ptr, len);
+    r->v.p.ptr[len] = '\0';
     r->v.p.length = strlen(r->v.p.ptr) + 1;
 
     // alltrim


### PR DESCRIPTION
Hi Chris,

I found the following bug with RTRIM:

```
s1 = "   test   "
s2 = rtrim(s1)
print "<" + s1 + ">"      ' Output: <   test>
print "<" + s2 + ">"      ' Output: <   test>
```

Expected output would be, that the input string s1 stays as it is. Instead it got also right trimed.
