### PR TITLE
Fix bug #149: Problem with big hex numbers in windows

### DIFF
--- a/samples/distro-examples/tests/matrices.bas
+++ b/samples/distro-examples/tests/matrices.bas
@@ -64,3 +64,17 @@ m3rotate m, 2
 m3Apply m, strip
 if (strip != [[-18.23450585285103,14.19218649794793],[-10.96012643824558,17.52136119032507]]) then throw "m3Apply failed"
 
+A = [1;2;3;4]
+B = transpose(A)
+if (B[0] != 1) then throw "Error TRANSPOSE()"
+if (B[1] != 2) then throw "Error TRANSPOSE()"
+if (B[2] != 3) then throw "Error TRANSPOSE()"
+if (B[3] != 4) then throw "Error TRANSPOSE()"
+A = [1,2; 3,4; 5,6]
+B = transpose(A)
+if (B[0,0] != 1) then throw "Error TRANSPOSE()"
+if (B[0,1] != 3) then throw "Error TRANSPOSE()"
+if (B[0,2] != 5) then throw "Error TRANSPOSE()"
+if (B[1,0] != 2) then throw "Error TRANSPOSE()"
+if (B[1,1] != 4) then throw "Error TRANSPOSE()"
+if (B[1,2] != 6) then throw "Error TRANSPOSE()"

--- a/src/common/blib_func.c
+++ b/src/common/blib_func.c
@@ -2810,8 +2810,8 @@ void cmd_genfunc(long funcCode, var_t *r) {
     
     var_num_t *m = (var_num_t *)malloc(((rows) * (cols)) * sizeof(var_num_t));
     
-    for(int32_t x = 0; x < cols; x++) {
-      for(int32_t y = 0; y < rows; y++) {
+    for (int32_t x = 0; x < cols; x++) {
+      for (int32_t y = 0; y < rows; y++) {
         pos1 = y * cols + x;
         pos2 = x * rows + y;        
         e = v_elem(a, pos1);
@@ -2819,7 +2819,7 @@ void cmd_genfunc(long funcCode, var_t *r) {
       }
     }
 
-    if(cols > 1) {
+    if (cols > 1) {
       mat_tov(r, m, cols, rows, 1);
     } else {
       mat_tov(r, m, rows, 1, 0);

--- a/src/common/blib_func.c
+++ b/src/common/blib_func.c
@@ -2784,6 +2784,51 @@ void cmd_genfunc(long funcCode, var_t *r) {
   }
     break;
     //
+    // array <- TRANSPOSE(a)
+    //
+  case kwTRANSPOSE: {
+    int32_t rows, cols, pos1, pos2;
+    var_t *e;
+
+    v_init(r);
+    var_t *a = par_getvarray();  
+    IF_ERR_RETURN;    
+    
+    if (v_maxdim(a) > 2) {
+      err_matdim();
+      IF_ERR_RETURN;
+    }
+    
+    rows = ABS(v_lbound(a, 0) - v_ubound(a, 0)) + 1;
+
+    if (v_maxdim(a) == 2) {
+      cols = ABS(v_lbound(a, 1) - v_ubound(a, 1)) + 1;
+    } else {
+      cols = rows;
+      rows = 1;
+    }
+    
+    var_num_t *m = (var_num_t *)malloc(((rows) * (cols)) * sizeof(var_num_t));
+    
+    for(int32_t x = 0; x < cols; x++) {
+      for(int32_t y = 0; y < rows; y++) {
+        pos1 = y * cols + x;
+        pos2 = x * rows + y;        
+        e = v_elem(a, pos1);
+        m[pos2] = v_getval(e);
+      }
+    }
+
+    if(cols > 1) {
+      mat_tov(r, m, cols, rows, 1);
+    } else {
+      mat_tov(r, m, rows, 1, 0);
+    }
+    
+    free(m);    
+  }
+    break;
+    //
     // n <- DETERM(A)
     //
   case kwDETERM: {

--- a/src/common/eval.c
+++ b/src/common/eval.c
@@ -1205,6 +1205,7 @@ static inline void eval_callf(var_t *r) {
   case kwGAUSSJORDAN:
   case kwFILES:
   case kwINVERSE:
+  case kwTRANSPOSE:
   case kwDETERM:
   case kwJULIAN:
   case kwDATEFMT:

--- a/src/common/kw.h
+++ b/src/common/kw.h
@@ -366,6 +366,7 @@ enum func_keywords {
   kwGAUSSJORDAN,
   kwFILES,
   kwINVERSE,
+  kwTRANSPOSE,
   kwDETERM,
   kwJULIAN,
   kwDATEFMT,

--- a/src/common/str.c
+++ b/src/common/str.c
@@ -555,8 +555,8 @@ var_int_t numexpr_strtol(char *source) {
 /**
  * convertion: binary to decimal
  */
-long bintol(const char *str) {
-  long r = 0;
+var_int_t bintol(const char *str) {
+  var_int_t r = 0;
   char *p = (char *) str;
 
   if (p == NULL) {
@@ -575,8 +575,8 @@ long bintol(const char *str) {
 /**
  * convertion: octal to decimal
  */
-long octtol(const char *str) {
-  long r = 0;
+var_int_t octtol(const char *str) {
+  var_int_t r = 0;
   char *p = (char *) str;
 
   if (p == NULL) {
@@ -595,8 +595,8 @@ long octtol(const char *str) {
 /**
  * convertion: hexadecimal to decimal
  */
-long hextol(const char *str) {
-  long r = 0;
+var_int_t hextol(const char *str) {
+  var_int_t r = 0;
   char *p = (char *) str;
 
   if (p == NULL) {

--- a/src/common/str.h
+++ b/src/common/str.h
@@ -170,7 +170,7 @@ void str_alltrim(char *str);
  * @param str the string
  * @return the number
  */
-long bintol(const char *str);
+var_int_t bintol(const char *str);
 
 /**
  * @ingroup str
@@ -180,7 +180,7 @@ long bintol(const char *str);
  * @param str the string
  * @return the number
  */
-long octtol(const char *str);
+var_int_t octtol(const char *str);
 
 /**
  * @ingroup str
@@ -190,7 +190,7 @@ long octtol(const char *str);
  * @param str the string
  * @return the number
  */
-long hextol(const char *str);
+var_int_t hextol(const char *str);
 
 /**
  * @ingroup str

--- a/src/languages/keywords.en.c
+++ b/src/languages/keywords.en.c
@@ -308,6 +308,7 @@ struct func_keyword_s func_table[] = {
 { "LINEQN",                     kwGAUSSJORDAN },
 { "FILES",                      kwFILES },
 { "INVERSE",                    kwINVERSE },
+{ "TRANSPOSE",                  kwTRANSPOSE },
 { "DETERM",                     kwDETERM },
 { "JULIAN",                     kwJULIAN },
 { "DATEFMT",                    kwDATEFMT },


### PR DESCRIPTION
Hi Chris,

Commit 1:
I fixed bug #149 problem with big hex numbers in windows. The problem is, that Linux 64 bit and Windows 64 bit have different length for long (linux -> 64 bit, windows -> 32 bit). I changed the length to var_int_t. See: https://www.ibm.com/docs/en/ibm-mq/9.1?topic=platforms-standard-data-types-unix-linux-windows

Commit 2:
I added the new SB function TRANSPOSE. It returns the transpose of a Matrix (or vector).

Best regards, Joerg