### PR TITLE
Fix #232: TICKS stops working after 50 days

### DIFF
--- a/src/common/device.h
+++ b/src/common/device.h
@@ -1037,7 +1037,7 @@ void dev_destroy_file_list(char_p_t *list, int count);
  * Returns the number of milliseconds that has passed since
  * some unknown point in time.
  */
-uint32_t dev_get_millisecond_count();
+uint64_t dev_get_millisecond_count();
 
 /**
  * @ingroup dev_f

--- a/src/common/system.c
+++ b/src/common/system.c
@@ -216,24 +216,23 @@ const char *dev_getenv_n(int n) {
 }
 #endif
 
-uint32_t dev_get_millisecond_count(void) {
+uint64_t dev_get_millisecond_count(void) {
 #if defined(__MACH__)
   struct timeval t;
   gettimeofday(&t, NULL);
-  return (uint32_t) (1000L * t.tv_sec + (t.tv_usec / 1000.0));
+  return (uint64_t) (1000L * t.tv_sec + (t.tv_usec / 1000.0));
 #elif defined(_Win32)
   return GetTickCount();
 #else
   struct timespec t;
   t.tv_sec = t.tv_nsec = 0;
   if (0 == clock_gettime(CLOCK_MONOTONIC, &t)) {
-    return (uint32_t) (1000L * t.tv_sec + (t.tv_nsec / 1e6));
+    return (uint64_t) (1000L * t.tv_sec + (t.tv_nsec / 1e6));
   } else {
     struct timeval now;
     gettimeofday(&now, NULL);
-    return (uint32_t) (1000L * now.tv_sec + (now.tv_usec / 1000.0));
+    return (uint64_t) (1000L * now.tv_sec + (now.tv_usec / 1000.0));
   }
 #endif
 }
-
 


### PR DESCRIPTION
Hi Chris,

here a fix for the bug, that TICKS stops working after 50 days. It was a uint32 problem. I changed to uint64. That should give a little bit more time until TICKS will stop.

Best regards, Joerg

