### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ SmallBASIC is a fast and easy to learn BASIC language interpreter ideal for ever
 
 #### Install packages
 
-Ubuntu
+Ubuntu (25.04)
 
 ```
-sudo apt-get install git autotools-dev automake gcc g++ libsdl2-dev libfreetype6-dev libfontconfig1-dev xxd
+sudo apt install git autotools-dev automake make gcc g++ libsdl3-dev libfreetype-dev libfontconfig-dev xxd
 ```
 
 Manjaro (Arch)
 
 ```
-sudo pacman -S gcc make autoconf automake sdl2 freetype2 fontconfig pkgconf vim
+sudo pacman -S gcc make autoconf automake sdl3 freetype2 fontconfig pkgconf vim
 ```
 
 #### Initial setup
@@ -23,7 +23,6 @@ sudo pacman -S gcc make autoconf automake sdl2 freetype2 fontconfig pkgconf vim
 ```
  $ git clone https://github.com/smallbasic/SmallBASIC.git
  $ cd SmallBASIC
- $ git submodule update --init
  $ sh autogen.sh
 ```
 
@@ -95,7 +94,6 @@ $ brew install autoconf
 ```
 $ git clone https://github.com/smallbasic/SmallBASIC.git
 $ cd SmallBASIC
-$ git submodule update --init
 $ sh autogen.sh
 ```
 

--- a/src/platform/console/device.cpp
+++ b/src/platform/console/device.cpp
@@ -104,6 +104,7 @@ void default_write(const char *str) {
       }
     }
   }
+  fflush(stdout);
 }
 
 //
@@ -111,6 +112,7 @@ void default_write(const char *str) {
 //
 void vt100_write(const char *str) {
   printf("%s", str);
+  fflush(stdout);
 }
 
 void console_init() {


### PR DESCRIPTION
The SDL version of SmallBASIC uses SDL3 now. Update of build instructions for Ubuntu 25.04 and Manjaro.